### PR TITLE
Invoke podman/docker run afresh in a container restart instead of "container stop/start"

### DIFF
--- a/src/ybox/cmd.py
+++ b/src/ybox/cmd.py
@@ -147,7 +147,7 @@ def check_active_ybox(docker_cmd: str, box_name: str, exit_on_error: bool = Fals
     :param exit_on_error: whether to exit using `sys.exit` if the check fails
     :return: if `exit_on_error` is False, then return the result of verification as True or False
     """
-    return bool(get_ybox_state(docker_cmd, box_name, expected_states=("running",),
+    return bool(get_ybox_state(docker_cmd, box_name, expected_states=("running", "stopping"),
                                exit_on_error=exit_on_error, state_msg=" active"))
 
 

--- a/src/ybox/cmd.py
+++ b/src/ybox/cmd.py
@@ -5,6 +5,7 @@ Utilities related to command execution like running a command, get podman/docker
 import argparse
 import errno
 import shlex
+import shutil
 import subprocess
 import sys
 from enum import Enum
@@ -12,6 +13,7 @@ from typing import Callable, Iterable
 
 from ybox import __version__ as product_version
 from ybox.config import Consts
+from ybox.env import Environ
 
 from .print import print_error, print_info, print_notice, print_warn
 
@@ -379,3 +381,17 @@ def populate_exec_cmdline(docker_cmd: str, box_name: str, escape_str: str, is_in
             cmd.append(arg)
     cmd.extend((" ", box_name, " /usr/local/bin/run-in-dir ", escape_str, '"', working_dir,
                 escape_str, '" '))
+
+
+def delete_container_directory(container_dir: str, env: Environ) -> None:
+    """delete given directory which hosts a directory mounted in a container"""
+    if env.uses_podman:
+        if run_command([env.docker_cmd, "unshare", "/bin/rm", "-rf", container_dir],
+                       exit_on_error=False, error_msg="deleting container directory") == 0:
+            return
+    try:
+        shutil.rmtree(container_dir)
+    except OSError:
+        # try with sudo
+        run_command(["/usr/bin/sudo", "/bin/rm", "-rf", container_dir],
+                    error_msg="deleting container directory")

--- a/src/ybox/conf/distros/arch/distro.ini
+++ b/src/ybox/conf/distros/arch/distro.ini
@@ -22,9 +22,8 @@ name = Arch Linux
 includes =
 # points to the daily updated image to minimize upgrade size
 image = docker.io/archlinux/archlinux:latest
-# directories which are shared between the containers of a distribution when
-# `shared_root` is provided in the container configuration
-shared_root_dirs = /etc,/opt,/usr,/var
+# root sub-directories in the container that are mounted on the host for persistence
+mount_root_dirs = /etc,/opt,/usr,/var
 # the secondary groups of the container user; it requires to include at least the equivalent of
 # nobody/nogroup to work correctly (the last field in /etc/subgid)
 secondary_groups = nobody,wheel,video,input,lp,mail
@@ -51,10 +50,10 @@ recommended_deps = intel-media-driver libva-mesa-driver vulkan-intel vulkan-mesa
 # optional packages for enhanced experience in shell and GUI apps
 # (for some reason TERMINFO_DIRS does not work for root user, so explicitly installing terminfo
 #  packages for other terminal emulators available in arch which occupy only a tiny space)
-suggested = cantarell-fonts ttf-fira-code noto-fonts neovim eza ncdu fd bat gnome-settings-daemon
-            kitty-terminfo rxvt-unicode-terminfo realtime-privileges tree starship
+suggested = noto-fonts neovim gnome-settings-daemon kitty-terminfo rxvt-unicode-terminfo
+            realtime-privileges starship
 # dependencies of the `suggested` packages
-suggested_deps = xsel
+suggested_deps = xsel wl-clipboard
 # additional packages that are in AUR and installed by yay in init-user.sh
 extra = neovim-symlinks tinyxxd
 

--- a/src/ybox/conf/distros/arch/init.sh
+++ b/src/ybox/conf/distros/arch/init.sh
@@ -29,15 +29,13 @@ if [ -n "$LANG" -a "$LANG" != "C.UTF-8" ] && ! grep -q "^$LANG UTF-8" /etc/local
   if [ "$LANG" != "en_US.UTF-8" ]; then
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
   fi
+  # reinstall glibc to obtain /usr/share/i18/locales/* files and try again
+  $PAC -Sy
+  $PAC -S glibc
   if ! locale-gen; then
-    # reinstall glibc to obtain /usr/share/i18/locales/* files and try again
-    $PAC -Sy
-    $PAC -S glibc
-    if ! locale-gen; then
-      echo_color "$fg_red" "FAILED to generate locale for $LANG, fallback to en_US.UTF-8" >> $status_file
-      export LANG=en_US.UTF-8
-      export LANGUAGE="en_US:en"
-    fi
+    echo_color "$fg_red" "FAILED to generate locale for $LANG, fallback to en_US.UTF-8" >> $status_file
+    export LANG=en_US.UTF-8
+    export LANGUAGE="en_US:en"
   fi
   echo "LANG=$LANG" > /etc/locale.conf
   if [ -n "$LANGUAGE" ]; then

--- a/src/ybox/conf/distros/deb-generic/distro.ini
+++ b/src/ybox/conf/distros/deb-generic/distro.ini
@@ -22,9 +22,8 @@ name = Generic Debian/Ubuntu distribution
 includes =
 # docker image of the distribution
 image =
-# directories which are shared between the containers of a distribution when
-# `shared_root` is provided in the container configuration
-shared_root_dirs = /etc,/opt,/usr,/var
+# root sub-directories in the container that are mounted on the host for persistence
+mount_root_dirs = /etc,/opt,/usr,/var
 # the secondary groups of the container user; it requires to include at least the equivalent of
 # nobody/nogroup to work correctly (the last field in /etc/subgid)
 secondary_groups = nogroup,sudo,video,input,lp,mail
@@ -52,10 +51,9 @@ recommended = bc man-db manpages pulseaudio-utils bzip2 xz-utils zstd fastjar wg
 recommended_deps = xauth netbase xdg-user-dirs intel-media-va-driver-non-free mesa-va-drivers
                    mesa-vulkan-drivers libfribidi0 fonts-dejavu-core sensible-utils libpam-cap
 # optional packages for enhanced experience in shell and GUI apps
-suggested = fonts-cantarell fonts-firacode fonts-noto-core neovim ncdu fd-find bat
-            gnome-settings-daemon-common kitty-terminfo tree
+suggested = fonts-noto-core neovim fd-find gnome-settings-daemon-common kitty-terminfo
 # dependencies of the `suggested` packages
-suggested_deps = xsel xxd
+suggested_deps = xsel wl-clipboard xxd
 
 
 # The commands here will be run as normal userns mapped user, so use sudo if the command

--- a/src/ybox/conf/resources/entrypoint-root.sh
+++ b/src/ybox/conf/resources/entrypoint-root.sh
@@ -9,11 +9,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/entrypoint-common.sh"
 
 export HOME=/root
-echo_color "$fg_cyan" "Copying prime-run, run-in-dir and run-user-bash-cmd" >> $status_file
-cp -af "$SCRIPT_DIR/prime-run" /usr/local/bin/prime-run
-cp -af "$SCRIPT_DIR/run-in-dir" /usr/local/bin/run-in-dir
-cp -af "$SCRIPT_DIR/run-user-bash-cmd" /usr/local/bin/run-user-bash-cmd
-chmod 0755 /usr/local/bin/prime-run /usr/local/bin/run-in-dir /usr/local/bin/run-user-bash-cmd
+if [ ! -e "$SCRIPT_DIR/ybox-init.done" ]; then
+  echo_color "$fg_cyan" "Copying prime-run, run-in-dir and run-user-bash-cmd" >> $status_file
+  cp -af "$SCRIPT_DIR/prime-run" /usr/local/bin/prime-run
+  cp -af "$SCRIPT_DIR/run-in-dir" /usr/local/bin/run-in-dir
+  cp -af "$SCRIPT_DIR/run-user-bash-cmd" /usr/local/bin/run-user-bash-cmd
+  chmod 0755 /usr/local/bin/prime-run /usr/local/bin/run-in-dir /usr/local/bin/run-user-bash-cmd
+fi
 
 # invoke the NVIDIA setup script if present
 if [ -r "$SCRIPT_DIR/nvidia-setup.sh" ]; then

--- a/src/ybox/conf/resources/ybox-systemd.template
+++ b/src/ybox/conf/resources/ybox-systemd.template
@@ -9,7 +9,7 @@ After=network-online.target
 {docker_requires}
 [Service]
 Environment=PATH={sys_path}:{ybox_bin_dir}
-EnvironmentFile=%h/.config/systemd/user/{env_file}
+EnvironmentFile=%h/.config/ybox/{env_file}
 Type=notify
 NotifyAccess=all
 Restart=on-failure

--- a/src/ybox/conf/resources/ybox-systemd.template
+++ b/src/ybox/conf/resources/ybox-systemd.template
@@ -13,11 +13,11 @@ EnvironmentFile=%h/.config/systemd/user/{env_file}
 Type=notify
 NotifyAccess=all
 Restart=on-failure
-# sleep to allow for initialization of the user's login/graphical environment
+# sleep to allow for the basic initialization of the user's login/graphical environment
 ExecStartPre=/usr/bin/sleep $SLEEP_SECS
-ExecStart=/bin/sh -c 'ybox-control start {name} && systemd-notify --ready && exec ybox-control wait {name}'
-ExecStop=/bin/sh -c 'ybox-control stop -t 20 --ignore-stopped {name}'
-ExecStopPost=/bin/sh -c 'ybox-control stop -t 20 --ignore-stopped {name}'
+ExecStart=/bin/sh -c "eval $YBOX_CONTAINER_MANAGER run $CONTAINER_ARGS && systemd-notify --ready && exec ybox-control wait {name}"
+ExecStop=/bin/sh -c "ybox-control stop -t 20 --ignore-stopped --rm {name}"
+ExecStopPost=/bin/sh -c "ybox-control stop -t 20 --ignore-stopped --rm {name}"
 TimeoutStopSec=60
 
 [Install]

--- a/src/ybox/conf/resources/ybox-systemd.template
+++ b/src/ybox/conf/resources/ybox-systemd.template
@@ -15,7 +15,7 @@ NotifyAccess=all
 Restart=on-failure
 # sleep to allow for the basic initialization of the user's login/graphical environment
 ExecStartPre=/usr/bin/sleep $SLEEP_SECS
-ExecStart=/bin/sh -c "eval $YBOX_CONTAINER_MANAGER run $CONTAINER_ARGS && systemd-notify --ready && exec ybox-control wait {name}"
+ExecStart=/bin/sh -c "eval $YBOX_CONTAINER_MANAGER run $CONTAINER_RUN_ARGS && systemd-notify --ready && exec ybox-control wait {name}"
 ExecStop=/bin/sh -c "ybox-control stop -t 20 --ignore-stopped --rm {name}"
 ExecStopPost=/bin/sh -c "ybox-control stop -t 20 --ignore-stopped --rm {name}"
 TimeoutStopSec=60

--- a/src/ybox/config.py
+++ b/src/ybox/config.py
@@ -88,6 +88,13 @@ class StaticConfiguration:
         """
         return self._shared_box_image if has_shared_root else self._box_image
 
+    def unshared_root(self) -> str:
+        """
+        path of the directory on the host used for storing root subdirs of the container for the
+        case when `shared_root` is not set (i.e. a unique directory is used for the container).
+        """
+        return f"{self._env.data_dir}/{self._box_name}/ROOT"
+
     @property
     def localtime(self) -> str | None:
         """the target link for /etc/localtime"""
@@ -200,8 +207,8 @@ class Consts:
                 "prime-run", "run-in-dir", Consts.run_user_bash_cmd())
 
     @staticmethod
-    def shared_root_mount_dir() -> str:
-        """directory where shared root directory is mounted in a container during setup"""
+    def root_mount_dir() -> str:
+        """directory where container's root directory is mounted in a container during setup"""
         return "/ybox-root"
 
     @staticmethod

--- a/src/ybox/env.py
+++ b/src/ybox/env.py
@@ -97,6 +97,7 @@ class Environ:
         self._user_base = user_base = site.getuserbase()
         target_user_base = f"{self._target_home}/.local"
         self._data_dir = f"{user_base}/share/ybox"
+        self._config_dir = f"{self._home_dir}/.config/ybox"
         self._target_data_dir = f"{target_user_base}/share/ybox"
         self._xdg_rt_dir = os.environ.get("XDG_RUNTIME_DIR", "").rstrip("/")
         # the container user's one can be different because it is the root user for docker
@@ -113,8 +114,7 @@ class Environ:
             print_notice("Running with YBOX_TESTING enabled")
             self._configuration_dirs = self._sys_conf_dirs
         else:
-            self._configuration_dirs = [Path(f"{self._home_dir}/.config/ybox"),
-                                        sys_conf_dir]
+            self._configuration_dirs = [Path(self._config_dir), sys_conf_dir]
         self._user_applications_dir = f"{user_base}/share/applications"
         self._user_executables_dir = f"{user_base}/bin"
 
@@ -182,6 +182,11 @@ class Environ:
         """base user directory where runtime data related to all the containers is
            stored in subdirectories"""
         return self._data_dir
+
+    @property
+    def config_dir(self) -> str:
+        """base user directory where configuration data related to the ybox application is stored"""
+        return self._config_dir
 
     @property
     def target_data_dir(self) -> str:

--- a/src/ybox/pkg/inst.py
+++ b/src/ybox/pkg/inst.py
@@ -178,7 +178,8 @@ def _install_package(package: str, args: argparse.Namespace, install_cmd: str, l
         if args.keep_ambient_caps:
             app_flags[package + ":ambient_caps"] = "keep"
         local_copies = wrap_container_files(package, copy_type, app_flags, list_cmd, docker_cmd,
-                                            conf, rt_conf.ini_config, rt_conf.shared_root, quiet)
+                                            conf, rt_conf.ini_config,
+                                            rt_conf.shared_root or conf.unshared_root(), quiet)
         dep_type, dep_of = (DependencyType.OPTIONAL, args.package) if opt_dep_install else (
             None, "")
         state.register_package(conf.box_name, package, local_copies, copy_type, app_flags,
@@ -305,7 +306,7 @@ def select_optional_deps(package: str, deps: list[tuple[str, str, int]]) -> list
 
 def wrap_container_files(package: str, copy_type: CopyType, app_flags: dict[str, str],
                          list_cmd: str, docker_cmd: str, conf: StaticConfiguration,
-                         box_conf: str | ConfigParser, shared_root: str,
+                         box_conf: str | ConfigParser, container_root: str,
                          quiet: int) -> list[str]:
     """
     Create wrappers in host environment to invoke container's desktop files and executables.
@@ -319,8 +320,7 @@ def wrap_container_files(package: str, copy_type: CopyType, app_flags: dict[str,
     :param conf: the :class:`StaticConfiguration` for the container
     :param box_conf: the resolved INI format configuration of the container as a string or
                      a `ConfigParser` object
-    :param shared_root: the local shared root directory if `shared_root` is provided
-                        for the container
+    :param container_root: the directory on the host used for the root subdirs of the container
     :param quiet: perform operations quietly
     :return: the list of paths of the wrapper files
     """
@@ -341,7 +341,7 @@ def wrap_container_files(package: str, copy_type: CopyType, app_flags: dict[str,
     executable_dirs = Consts.container_bin_dirs()
     man_dir_pattern = Consts.container_man_dir_pattern()
     # get the parsed container configuration
-    parsed_box_conf = _get_parsed_box_conf(box_conf)
+    parsed_box_conf = get_parsed_box_conf(box_conf)
     # read the container configuration for [app_flags] section
     app_flags_section = parsed_box_conf["app_flags"] \
         if parsed_box_conf and parsed_box_conf.has_section("app_flags") else None
@@ -379,15 +379,15 @@ def wrap_container_files(package: str, copy_type: CopyType, app_flags: dict[str,
             if file_dir in executable_dirs:
                 _wrap_executable(filename, file, docker_cmd, conf, app_flags, needs_tty,
                                  keep_ambient_caps, wrapper_files)
-            elif shared_root and man_dir_pattern.match(file_dir):
-                _link_man_page(file, shared_root, conf, wrapper_files)
+            elif container_root and man_dir_pattern.match(file_dir):
+                _link_man_page(file, container_root, conf, wrapper_files)
     if selected_icons:
         _copy_app_icons(selected_icons, docker_cmd, conf, quiet, wrapper_files)
 
     return wrapper_files
 
 
-def _get_parsed_box_conf(box_conf: str | ConfigParser) -> ConfigParser | None:
+def get_parsed_box_conf(box_conf: str | ConfigParser) -> ConfigParser | None:
     """
     Get the parsed `ConfigParser` for the container configuration.
 
@@ -673,14 +673,13 @@ def _get_wrapper_executable(filename: str, conf: StaticConfiguration) -> str:
     return f"{conf.env.user_executables_dir}/{filename}"
 
 
-def _link_man_page(file: str, shared_root: str, conf: StaticConfiguration,
+def _link_man_page(file: str, container_root: str, conf: StaticConfiguration,
                    wrapper_files: list[str]) -> None:
     """
-    For an executable, create a wrapper executable that invokes "podman/docker exec".
+    Link man pages of the given program (`file`) in the user's host standard man directory.
 
-    :param file: full path of the executable file being wrapped
-    :param shared_root: the local shared root directory if `shared_root` is provided
-                        for the container
+    :param file: full path of the executable file for which the man page has to be linked
+    :param container_root: the directory on the host used for the root subdirs of the container
     :param conf: the :class:`StaticConfiguration` for the container
     :param wrapper_files: the accumulated list of all wrapper files so far
     """
@@ -689,5 +688,5 @@ def _link_man_page(file: str, shared_root: str, conf: StaticConfiguration,
     print_notice(f"Linking man page {file} to {linked_man_page}")
     linked_man_page.parent.mkdir(parents=True, exist_ok=True)
     linked_man_page.unlink(missing_ok=True)
-    linked_man_page.symlink_to(f"{shared_root}{file}")
+    linked_man_page.symlink_to(f"{container_root}{file}")
     wrapper_files.append(str(linked_man_page))

--- a/src/ybox/run/control.py
+++ b/src/ybox/run/control.py
@@ -51,20 +51,23 @@ def stop_container(docker_cmd: str, args: argparse.Namespace):
     :param docker_cmd: the podman/docker executable to use
     :param args: arguments having all attributes passed by the user
     """
-    _stop_container(docker_cmd, args.container, args.timeout,
+    _stop_container(docker_cmd, args.container, args.timeout, args.rm, args.force_rm,
                     fail_on_error=not args.ignore_stopped)
 
 
 def _stop_container(docker_cmd: str, container_name: str, timeout: int,
-                    fail_on_error: bool):
+                    remove: bool, force_remove: bool, fail_on_error: bool):
     """
     Stop an active ybox container.
 
     :param docker_cmd: the podman/docker executable to use
     :param container_name: name of the container
     :param timeout: seconds to wait for container to stop before killing the container
+    :param remove: also remove the container after a successful stop
+    :param force_remove: force remove the container after a successful stop
     :param fail_on_error: if True then show error message on failure to stop else ignore
     """
+    exit_code = 0
     if check_active_ybox(docker_cmd, container_name):
         print_color(f"Stopping ybox container '{container_name}'", fg=fgcolor.cyan)
         run_command([docker_cmd, "container", "stop", "-t", str(timeout), container_name],
@@ -73,13 +76,32 @@ def _stop_container(docker_cmd: str, container_name: str, timeout: int,
             time.sleep(0.5)
             if get_ybox_state(docker_cmd, container_name, ("exited", "stopped"),
                               exit_on_error=False, state_msg=" stopped"):
-                return
-        print_error(f"Failed to stop ybox container '{container_name}'")
+                exit_code = 0
+                break
+        else:
+            print_error(f"Failed to stop ybox container '{container_name}'")
+            exit_code = 1
     elif fail_on_error:
         print_error(f"No active ybox container '{container_name}' found")
         sys.exit(1)
     else:
         print_color(f"No active ybox container '{container_name}' found", fg=fgcolor.cyan)
+
+    action = "stop"
+    if remove:
+        action = "remove"
+        msg = "container rm" if fail_on_error else "SKIP"
+        exit_code = run_command([docker_cmd, "container", "rm", container_name],
+                                exit_on_error=False, error_msg=msg)
+    elif force_remove:
+        action = "force remove"
+        msg = "container rm --force" if fail_on_error else "SKIP"
+        exit_code = run_command([docker_cmd, "container", "rm", "-t", str(timeout), "--force",
+                                 container_name], exit_on_error=False, error_msg=msg)
+    if exit_code != 0:
+        print_error(f"Failed to {action} ybox container '{container_name}' (code = {exit_code})")
+        if fail_on_error:
+            sys.exit(int(exit_code))
 
 
 def restart_container(docker_cmd: str, args: argparse.Namespace):
@@ -89,7 +111,8 @@ def restart_container(docker_cmd: str, args: argparse.Namespace):
     :param docker_cmd: the podman/docker executable to use
     :param args: arguments having all attributes passed by the user
     """
-    _stop_container(docker_cmd, args.container, timeout=int(args.timeout / 2), fail_on_error=False)
+    _stop_container(docker_cmd, args.container, timeout=int(args.timeout / 2), remove=False,
+                    force_remove=False, fail_on_error=False)
     start_container(docker_cmd, args)
 
 
@@ -149,6 +172,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     stop = operations.add_parser("stop", help="stop a ybox container")
     _add_subparser_args(stop, 10,
                         "time in seconds to wait for a container to stop before killing it")
+    stop.add_argument("-R", "--rm", action="store_true",
+                      help="also remove the container after a successful stop")
+    stop.add_argument("-F", "--force-rm", action="store_true",
+                      help="force removal of the container (implies -R/--rm)")
     stop.add_argument("-I", "--ignore-stopped", action="store_true",
                       help="don't fail on an already stopped container")
     stop.set_defaults(func=stop_container)

--- a/src/ybox/run/create.py
+++ b/src/ybox/run/create.py
@@ -203,7 +203,8 @@ def main_argv(argv: list[str]) -> None:
             systemctl := shutil.which("systemctl", path=sys_path)) and run_command(
                 [systemctl, "--user", "--quiet", "is-enabled", "default.target"],
                 exit_on_error=False) == 0:
-        create_and_start_service(box_name, env, systemctl, sys_path, wait_msg)
+        run_command([docker_full_args[0], "container", "rm", box_name], error_msg="container rm")
+        create_and_start_service(box_name, docker_full_args, env, systemctl, sys_path, wait_msg)
     else:
         if not args.skip_systemd_service:
             print_warn("Skipping user systemd service generation due to missing systemctl in "
@@ -212,7 +213,7 @@ def main_argv(argv: list[str]) -> None:
         start_container(docker_cmd, conf)
         print_info(wait_msg)
         wait_for_ybox_container(docker_cmd, conf, 120)
-    # truncate the app.list and config.list files so that those actions are skipped if the
+    # truncate the app.list and config.list files so that those actions are to be skipped if the
     # container is restarted later
     if os.access(conf.app_list, os.W_OK):
         truncate_file(conf.app_list)
@@ -1285,7 +1286,7 @@ def run_container(docker_full_cmd: list[str], current_user: str, shared_root: st
       * systemd user service file is generated for podman/docker to start the container
         automatically on user login (in absence of -S/--skip-systemd-service option)
 
-    :param docker_full_cmd: the `docker`/`podman run -itd` command with all the options filled
+    :param docker_full_cmd: the `podman`/`docker run` command with all the options filled
                             in from the container profile specification as a list of string
     :param current_user: the current user executing the `ybox-create` script
     :param shared_root: the shared root directory to use for the container
@@ -1340,12 +1341,14 @@ def run_container(docker_full_cmd: list[str], current_user: str, shared_root: st
         sys.exit(code)
 
 
-def create_and_start_service(box_name: str, env: Environ, systemctl: str, sys_path: str,
-                             wait_msg: str) -> None:
+def create_and_start_service(box_name: str, docker_full_cmd: list[str], env: Environ,
+                             systemctl: str, sys_path: str, wait_msg: str) -> None:
     """
     Create, enable and start systemd service for a ybox container.
 
     :param box_name: name of the ybox container
+    :param docker_full_cmd: the `podman`/`docker run` command with all the options filled
+                            in from the container profile specification as a list of string
     :param env: an instance of the current :class:`Environ`
     :param systemctl: resolved path to the `systemctl` utility
     :param sys_path: PATH used for searching system utilities
@@ -1378,7 +1381,8 @@ def create_and_start_service(box_name: str, env: Environ, systemctl: str, sys_pa
     env_content = f"""
         SLEEP_SECS={{sleep_secs}}
         # set the container manager to the one configured during ybox-create
-        YBOX_CONTAINER_MANAGER={env.docker_cmd}
+        YBOX_CONTAINER_MANAGER={docker_full_cmd[0]}
+        CONTAINER_ARGS='"{'" "'.join(docker_full_cmd[2:])}"'
     """
     os.makedirs(systemd_dir, Consts.default_directory_mode(), exist_ok=True)
     print_color(f"Generating user systemd service '{ybox_svc}' and reloading daemon", fgcolor.cyan)

--- a/src/ybox/run/create.py
+++ b/src/ybox/run/create.py
@@ -43,6 +43,10 @@ from ybox.util import (EnvInterpolation, config_reader,
 _EXTRACT_PARENS_NAME = re.compile(r"^.*\(([^)]+)\)$")
 _DEP_SUFFIX = re.compile(r"^(.*):dep\((.*)\)$")
 _WS_RE = re.compile(r"\s+")
+_PKG_VARS = (("required", "REQUIRED_PKGS"), ("recommended", "RECOMMENDED_PKGS"),
+             ("suggested", "SUGGESTED_PKGS"), ("required_deps", "REQUIRED_DEPS"),
+             ("recommended_deps", "RECOMMENDED_DEPS"), ("suggested_deps", "SUGGESTED_DEPS"),
+             ("extra", "EXTRA_PKGS"))
 
 
 # Note: deliberately not using os.path.join for joining paths since the code only works on
@@ -579,10 +583,7 @@ def process_distribution_config(distro_config: ConfigParser, docker_args: list[s
         add_env_option(docker_args, "CONFIGURE_FASTEST_MIRRORS", "1")
     if distro_config.has_section("packages"):
         packages_section = distro_config["packages"]
-        for key, env_var in (("required", "REQUIRED_PKGS"), ("recommended", "RECOMMENDED_PKGS"),
-                             ("suggested", "SUGGESTED_PKGS"), ("required_deps", "REQUIRED_DEPS"),
-                             ("recommended_deps", "RECOMMENDED_DEPS"),
-                             ("suggested_deps", "SUGGESTED_DEPS"), ("extra", "EXTRA_PKGS")):
+        for key, env_var in _PKG_VARS:
             if value := packages_section.get(key):
                 add_env_option(docker_args, env_var, _WS_RE.sub(" ", value))
     key_server = distro_config.get("repo", RepoCmd.DEFAULT_GPG_KEY_SERVER.value,
@@ -1305,7 +1306,7 @@ def run_container(docker_full_cmd: list[str], current_user: str, shared_root: st
         for shared_dir in shared_root_dirs.split(","):
             add_mount_option(docker_full_cmd, f"{shared_root}{shared_dir}", shared_dir)
     docker_full_cmd.append(f"-e=XDG_RUNTIME_DIR={conf.env.target_xdg_rt_dir}")
-    docker_full_cmd.append("-e=YBOX_TARGET_SCRIPTS_DIR")  # pass this along for container scripts
+    docker_full_cmd.append(f"-e=YBOX_TARGET_SCRIPTS_DIR={conf.target_scripts_dir}")
     docker_full_cmd.append(f"--label={YboxLabel.CONTAINER_PRIMARY.value}")
     docker_full_cmd.append(f"--label={YboxLabel.CONTAINER_DISTRIBUTION.value}={conf.distribution}")
     docker_full_cmd.append(f"--entrypoint={conf.target_scripts_dir}/{Consts.entrypoint()}")
@@ -1378,11 +1379,15 @@ def create_and_start_service(box_name: str, docker_full_cmd: list[str], env: Env
     svc_content = svc_tmpl.format(name=box_name, version=product_version, date=formatted_now,
                                   manager_name=manager_name, docker_requires=docker_requires,
                                   sys_path=sys_path, ybox_bin_dir=ybox_bin_dir, env_file=ybox_env)
+    # remove unneeded package install variables to reduce the overall size of CONTAINER_ARGS string
+    pkg_vars = {pkg[1] for pkg in _PKG_VARS}
+    container_args = [arg for arg in docker_full_cmd[2:]
+                      if not arg.startswith("-e=") or arg[3:].partition("=")[0] not in pkg_vars]
     env_content = f"""
         SLEEP_SECS={{sleep_secs}}
         # set the container manager to the one configured during ybox-create
         YBOX_CONTAINER_MANAGER={docker_full_cmd[0]}
-        CONTAINER_ARGS='"{'" "'.join(docker_full_cmd[2:])}"'
+        CONTAINER_ARGS='"{'" "'.join(container_args)}"'
     """
     os.makedirs(systemd_dir, Consts.default_directory_mode(), exist_ok=True)
     print_color(f"Generating user systemd service '{ybox_svc}' and reloading daemon", fgcolor.cyan)

--- a/src/ybox/run/create.py
+++ b/src/ybox/run/create.py
@@ -205,7 +205,7 @@ def main_argv(argv: list[str]) -> None:
     print_info("Waiting for the container to initialize (see "
                f"'ybox-logs -f {box_name}' for detailed progress)")
     # wait for container to initialize while printing out its progress from conf.status_file
-    wait_for_ybox_container(docker_cmd, conf, 600)
+    wait_for_ybox_container(docker_cmd, conf, 600, for_stop=True)
 
     # remove distribution specific scripts and restart container the final time
     print_info(f"Starting the final container '{box_name}'")
@@ -216,7 +216,7 @@ def main_argv(argv: list[str]) -> None:
             systemctl := shutil.which("systemctl", path=sys_path)) and run_command(
                 [systemctl, "--user", "--quiet", "is-enabled", "default.target"],
                 exit_on_error=False) == 0:
-        run_command([docker_full_args[0], "container", "rm", box_name], error_msg="container rm")
+        remove_container(docker_full_args[0], conf)
         create_and_start_service(box_name, docker_full_args, env, systemctl, sys_path, wait_msg)
     else:
         if not args.skip_systemd_service:

--- a/src/ybox/run/create.py
+++ b/src/ybox/run/create.py
@@ -1390,17 +1390,18 @@ def create_and_start_service(box_name: str, docker_full_cmd: list[str], env: Env
         CONTAINER_ARGS='"{'" "'.join(container_args)}"'
     """
     os.makedirs(systemd_dir, Consts.default_directory_mode(), exist_ok=True)
+    os.makedirs(env.config_dir, Consts.default_directory_mode(), exist_ok=True)
     print_color(f"Generating user systemd service '{ybox_svc}' and reloading daemon", fgcolor.cyan)
     with open(f"{systemd_dir}/{ybox_svc}", "w", encoding="utf-8") as svc_fd:
         svc_fd.write(svc_content)
-    with open(f"{systemd_dir}/{ybox_env}", "w", encoding="utf-8") as env_fd:
+    with open(f"{env.config_dir}/{ybox_env}", "w", encoding="utf-8") as env_fd:
         env_fd.write(dedent(env_content.format(sleep_secs=0)))  # don't sleep for the start below
     run_command([systemctl, "--user", "daemon-reload"], exit_on_error=False)
     run_command([systemctl, "--user", "enable", ybox_svc], exit_on_error=True)
     print_info(wait_msg)
     run_command([systemctl, "--user", "start", ybox_svc], exit_on_error=True)
     # change SLEEP_SECS to 5 for subsequent starts
-    with open(f"{systemd_dir}/{ybox_env}", "w", encoding="utf-8") as env_fd:
+    with open(f"{env.config_dir}/{ybox_env}", "w", encoding="utf-8") as env_fd:
         env_fd.write(dedent(env_content.format(sleep_secs=5)))
 
 

--- a/src/ybox/run/create.py
+++ b/src/ybox/run/create.py
@@ -21,7 +21,8 @@ from textwrap import dedent
 
 from ybox import __version__ as product_version
 from ybox.cmd import (PkgMgr, RepoCmd, YboxLabel, check_ybox_exists,
-                      parser_version_check, run_command)
+                      delete_container_directory, parser_version_check,
+                      run_command)
 from ybox.config import Consts, StaticConfiguration
 from ybox.env import Environ, NotSupportedError, PathName
 from ybox.filelock import FileLock
@@ -86,7 +87,7 @@ def main_argv(argv: list[str]) -> None:
 
     conf = StaticConfiguration(env, distro, box_name)
     # read the distribution specific configuration
-    base_image_name, shared_root_dirs, secondary_groups, distro_config = read_distribution_config(
+    base_image_name, mount_root_dirs, secondary_groups, distro_config = read_distribution_config(
         args, conf)
     # setup entrypoint and related scripts to share with the container on a mount point
     setup_ybox_scripts(conf, distro_config)
@@ -141,8 +142,10 @@ def main_argv(argv: list[str]) -> None:
     #    additional root directory mounts that were copied in step 5 above.
     # Finally, continue with step 4) onwards of previous sequence.
 
+    tmp_image = f"{conf.box_image(False)}__ybox_tmp"
     # handle the shared_root case: acquire file lock and check if shared container image exists
     if shared_root:
+        container_root = shared_root
         os.makedirs(os.path.dirname(shared_root),
                     mode=Consts.default_directory_mode(), exist_ok=True)
         with FileLock(f"{shared_root}-image.lock"):
@@ -160,31 +163,37 @@ def main_argv(argv: list[str]) -> None:
                 # commit the stopped container with a temporary name, then remove the container;
                 # keeping a separate tmp_image helps reduce size of final image a bit because
                 # this one is without --userns while the final shared image is with --userns
-                tmp_image = f"{conf.box_image(False)}__ybox_tmp"
                 commit_container(docker_cmd, tmp_image, conf)
                 # start a container using the temporary image with "--userns" option to make
                 # a copy of the container root directories to the shared location
-                run_shared_copy_container(docker_cmd, tmp_image, shared_root, shared_root_dirs,
-                                          conf, args.quiet)
+                run_root_copy_container(docker_cmd, tmp_image, shared_root, mount_root_dirs,
+                                        conf, args.quiet)
                 # finally commit this container with the name of the shared image
                 commit_container(docker_cmd, conf.box_image(True), conf)
                 remove_image(docker_cmd, tmp_image)
             # in case a shared root directory is not present but shared image is present,
             # need to run the container to copy to shared root
             elif any((not os.path.exists(f"{shared_root}{s_dir}") for s_dir in
-                      shared_root_dirs.split(","))):
-                run_shared_copy_container(docker_cmd, conf.box_image(True), shared_root,
-                                          shared_root_dirs, conf, args.quiet)
+                      mount_root_dirs.split(","))):
+                run_root_copy_container(docker_cmd, conf.box_image(True), shared_root,
+                                        mount_root_dirs, conf, args.quiet)
                 remove_container(docker_cmd, conf)
     else:
-        # fetch/refresh the base container image
-        _fetch_container_image(docker_cmd, base_image_name)
         # run the "base" container with appropriate arguments for the current user to the
         # 'entrypoint-base.sh' script to create the user and group in the container
         run_base_container(base_image_name, current_user, secondary_groups, docker_cmd, conf)
-        # commit the stopped container, remove it, then start new container with the
-        # "--userns=keep-id" option (podman) for the required container state
+        # commit the stopped container with a temporary name, then remove the container;
+        # keeping a separate tmp_image helps reduce size of final image a bit because
+        # this one is without --userns while the final shared image is with --userns
+        commit_container(docker_cmd, tmp_image, conf)
+        # start a container using the temporary image with "--userns" option to make
+        # a copy of the container root directories to the non-shared location which is fixed for now
+        container_root = conf.unshared_root()
+        run_root_copy_container(docker_cmd, tmp_image, container_root, mount_root_dirs,
+                                conf, args.quiet)
+        # finally commit this container with the name of the non-shared image
         commit_container(docker_cmd, conf.box_image(False), conf)
+        remove_image(docker_cmd, tmp_image)
 
     # there is one additional stop/start below because all packages are upgraded by the
     # entrypoint script to pick up any important fixes which can lead to system libraries
@@ -192,7 +201,7 @@ def main_argv(argv: list[str]) -> None:
 
     # set up the final container with all the required arguments
     print_info(f"Initializing container for '{distro}' using '{profile}'")
-    run_container(docker_full_args, current_user, shared_root, shared_root_dirs, conf)
+    run_container(docker_full_args, current_user, shared_root, mount_root_dirs, conf)
     print_info("Waiting for the container to initialize (see "
                f"'ybox-logs -f {box_name}' for detailed progress)")
     # wait for container to initialize while printing out its progress from conf.status_file
@@ -246,7 +255,7 @@ def main_argv(argv: list[str]) -> None:
                 quiet = 2 if args.quiet else 0
                 # box_conf can be skipped in new state.db but not for pre 0.9.3 having empty flags
                 if local_copies := wrap_container_files(package, copy_type, app_flags, list_cmd,
-                                                        docker_cmd, conf, box_conf, shared_root,
+                                                        docker_cmd, conf, box_conf, container_root,
                                                         quiet):
                     # register the package again with the local_copies (no change to package_deps)
                     state.register_package(box_name, package, local_copies, copy_type, app_flags,
@@ -275,11 +284,9 @@ def _fetch_container_image(docker_cmd: str, image_name: str) -> None:
     for _ in range(3):
         if int(run_command([docker_cmd, "pull", image_name], exit_on_error=False,
                            error_msg="fetching container base image")) == 0:
-            break
+            return
         time.sleep(5)
-    else:
-        run_command([docker_cmd, "pull", image_name],
-                    error_msg="fetching container base image")
+    run_command([docker_cmd, "pull", image_name], error_msg="fetching container base image")
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -548,8 +555,8 @@ def read_distribution_config(args: argparse.Namespace,
 
     :param args: the parsed arguments passed to the invoking `ybox-create` script
     :param conf: the :class:`StaticConfiguration` for the container
-    :return: a tuple of image name, shared root directories, secondary groups and an object of
-             :class:`ConfigParser` for the `distro.ini`
+    :return: a tuple of image name, container's root directories to be copied to host mount,
+             secondary groups and an object of :class:`ConfigParser` for the `distro.ini`
     """
     env = conf.env
     env_interpolation = EnvInterpolation(env, [])
@@ -564,9 +571,11 @@ def read_distribution_config(args: argparse.Namespace,
                      f"provided on the command-line: {args.distribution_image}")
         print()
         image_name = args.distribution_image
-    shared_root_dirs = distro_base_section["shared_root_dirs"]  # should always exist
+    # pre 0.9.15 releases use the obsolete `shared_root_dirs`
+    mount_root_dirs = distro_base_section.get("mount_root_dirs") or \
+        distro_base_section["shared_root_dirs"]
     secondary_groups = distro_base_section["secondary_groups"]  # should always exist
-    return image_name, shared_root_dirs, secondary_groups, distro_config
+    return image_name, mount_root_dirs, secondary_groups, distro_config
 
 
 def process_distribution_config(distro_config: ConfigParser, docker_args: list[str]) -> None:
@@ -1176,62 +1185,55 @@ def run_base_container(image_name: str, current_user: str, secondary_groups: str
     run_command(docker_run, error_msg="running container with base image")
 
 
-def run_shared_copy_container(docker_cmd: str, image_name: str, shared_root: str,
-                              shared_root_dirs: str, conf: StaticConfiguration,
-                              quiet: bool) -> None:
+def run_root_copy_container(docker_cmd: str, image_name: str, container_root: str,
+                            mount_root_dirs: str, conf: StaticConfiguration, quiet: bool) -> None:
     """
-    Start a container from a base distribution image (with minimal configuration) when
-    `shared_root` has been provided for the container and copy a configured set of directories
-    (`shared_root_dirs` in `distro.ini`) from the container to the `shared_root` directory.
-    This directory is then used as the root directory for all the final containers that share the
-    same `shared_root`.
+    Start a container from a base distribution image (with minimal configuration) to copy a
+    configured set of directories (`mount_root_dirs` in `distro.ini`) from the container to the
+    `container_root` directory. For the case of `shared_root`, this directory is used as the root
+    directory for all the final containers that share the same `shared_root`, else it is a
+    directory unique to this container.
 
-    If the provided `shared_root` directory already exists, then user is interactively asked
+    If the provided `container_root` directory already exists, then user is interactively asked
     whether to delete the existing directory before proceeding.
 
     :param docker_cmd: the podman/docker executable to use
     :param image_name: distribution image to use for the container as specified in `distro.ini`
-    :param shared_root: the shared root directory to use for the container
-    :param shared_root_dirs: comma-separate list of directories shared between containers having
-                             the same `shared_root`
+    :param container_root: the directory on the host to use for the root directory of the container
+    :param mount_root_dirs: comma-separate list of directories to be copied to the `container_root`
     :param conf: the :class:`StaticConfiguration` for the container
     :param quiet: if True then don't ask for user confirmation but assume a `no`
     """
-    # if shared root copy exists locally, then prompt user to delete it or else exit
-    if os.path.exists(shared_root):
+    # if the container root exists locally, then prompt user to delete it or else exit
+    if os.path.exists(container_root):
         input_msg = f"""
-            The shared root directory for '{conf.distribution}' already exists in:
-                {shared_root}
+            The root directory for '{conf.distribution}' already exists in:
+                {container_root}
             However, the corresponding ybox container image for '{conf.distribution}' does not
-            exist. This can happen if an old copy of shared root directory is lying around and
+            exist. This can happen if an old copy of the root directory is lying around and
             is usually safe to remove, but you should be sure that no other ybox is running
-            for '{conf.distribution}' with 'shared_root' configuration that is using that
+            for '{conf.distribution}' with 'container_root' configuration that is using that
             directory. Should the root directory be removed (y/N): """
         response = "N" if quiet else input(dedent(input_msg))
         if response.strip().lower() == "y":
-            try:
-                shutil.rmtree(shared_root)
-            except OSError:
-                # try with sudo
-                run_command(["/usr/bin/sudo", "/bin/rm", "-rf", shared_root],
-                            error_msg="deleting directory")
+            delete_container_directory(container_root, conf.env)
         else:
             print_error(f"Aborting creation of ybox container '{conf.box_name}'")
             # remove the temporary image before exit
             remove_image(docker_cmd, image_name)
             sys.exit(1)
-    os.makedirs(shared_root, mode=Consts.default_directory_mode())
+    os.makedirs(container_root, mode=Consts.default_directory_mode())
     # the entrypoint-cp.sh script requires two arguments: first is the comma separated
     # list of directories to be copied, and second the target directory
     docker_full_cmd = [docker_cmd, "run", f"--name={conf.box_name}",
                        f"-v={conf.scripts_dir}:{conf.target_scripts_dir}:ro",
-                       f"-v={shared_root}:{Consts.shared_root_mount_dir()}",
+                       f"-v={container_root}:{Consts.root_mount_dir()}",
                        f"--label={YboxLabel.CONTAINER_COPY.value}", "--user=0",
                        f"--entrypoint={conf.target_scripts_dir}/{Consts.entrypoint_cp()}"]
     if conf.env.uses_podman:
         docker_full_cmd.append("--userns=keep-id")
-    docker_full_cmd.extend((image_name, shared_root_dirs, Consts.shared_root_mount_dir()))
-    run_command(docker_full_cmd, error_msg="running container for copying shared root")
+    docker_full_cmd.extend((image_name, mount_root_dirs, Consts.root_mount_dir()))
+    run_command(docker_full_cmd, error_msg="running container for copying container's root")
 
 
 def commit_container(docker_cmd: str, image_name: str, conf: StaticConfiguration) -> None:
@@ -1262,7 +1264,7 @@ def remove_image(docker_cmd: str, image_name: str) -> None:
 
 
 def run_container(docker_full_cmd: list[str], current_user: str, shared_root: str,
-                  shared_root_dirs: str, conf: StaticConfiguration) -> None:
+                  root_dirs: str, conf: StaticConfiguration) -> None:
     """
     Create and start the final ybox container applying all the provided configuration.
     The following characteristics of the container are noteworthy:
@@ -1291,8 +1293,7 @@ def run_container(docker_full_cmd: list[str], current_user: str, shared_root: st
                             in from the container profile specification as a list of string
     :param current_user: the current user executing the `ybox-create` script
     :param shared_root: the shared root directory to use for the container
-    :param shared_root_dirs: comma-separate list of directories shared between containers having
-                             the same `shared_root`
+    :param root_dirs: comma-separate list of container's root sub-directories mounted on the host
     :param conf: the :class:`StaticConfiguration` for the container
     """
     add_mount_option(docker_full_cmd, conf.scripts_dir, conf.target_scripts_dir, "ro")
@@ -1302,9 +1303,9 @@ def run_container(docker_full_cmd: list[str], current_user: str, shared_root: st
     status_path.touch(mode=0o600, exist_ok=False)
     add_mount_option(docker_full_cmd, conf.status_file, Consts.status_target_file())
 
-    if shared_root:
-        for shared_dir in shared_root_dirs.split(","):
-            add_mount_option(docker_full_cmd, f"{shared_root}{shared_dir}", shared_dir)
+    container_root = shared_root or conf.unshared_root()
+    for root_subdir in root_dirs.split(","):
+        add_mount_option(docker_full_cmd, f"{container_root}{root_subdir}", root_subdir)
     docker_full_cmd.append(f"-e=XDG_RUNTIME_DIR={conf.env.target_xdg_rt_dir}")
     docker_full_cmd.append(f"-e=YBOX_TARGET_SCRIPTS_DIR={conf.target_scripts_dir}")
     docker_full_cmd.append(f"--label={YboxLabel.CONTAINER_PRIMARY.value}")
@@ -1365,9 +1366,8 @@ def create_and_start_service(box_name: str, docker_full_cmd: list[str], env: Env
         manager_name = "Docker"
         docker_requires = "After=docker.service\nRequires=docker.service\n"
     systemd_dir = env.systemd_user_conf_dir()
-    ybox_svc_prefix = ybox_systemd_service_prefix(box_name)
-    ybox_svc = f"{ybox_svc_prefix}.service"
-    ybox_env = f".{ybox_svc_prefix}.env"
+    ybox_svc = f"{ybox_systemd_service_prefix(box_name)}.service"
+    ybox_env = f"{box_name}.env"
     formatted_now = env.now.astimezone().strftime("%a %d %b %Y %H:%M:%S %Z")
     # get the path of ybox-control and replace $HOME by %h to keep it generic
     if ybox_ctrl_path := shutil.which("ybox-control"):
@@ -1379,15 +1379,15 @@ def create_and_start_service(box_name: str, docker_full_cmd: list[str], env: Env
     svc_content = svc_tmpl.format(name=box_name, version=product_version, date=formatted_now,
                                   manager_name=manager_name, docker_requires=docker_requires,
                                   sys_path=sys_path, ybox_bin_dir=ybox_bin_dir, env_file=ybox_env)
-    # remove unneeded package install variables to reduce the overall size of CONTAINER_ARGS string
+    # remove unneeded package install variables to reduce the overall size of CONTAINER_RUN_ARGS
     pkg_vars = {pkg[1] for pkg in _PKG_VARS}
-    container_args = [arg for arg in docker_full_cmd[2:]
-                      if not arg.startswith("-e=") or arg[3:].partition("=")[0] not in pkg_vars]
+    container_run_args = [arg for arg in docker_full_cmd[2:]
+                          if not arg.startswith("-e=") or arg[3:].partition("=")[0] not in pkg_vars]
     env_content = f"""
         SLEEP_SECS={{sleep_secs}}
         # set the container manager to the one configured during ybox-create
         YBOX_CONTAINER_MANAGER={docker_full_cmd[0]}
-        CONTAINER_ARGS='"{'" "'.join(container_args)}"'
+        CONTAINER_RUN_ARGS='"{'" "'.join(container_run_args)}"'
     """
     os.makedirs(systemd_dir, Consts.default_directory_mode(), exist_ok=True)
     os.makedirs(env.config_dir, Consts.default_directory_mode(), exist_ok=True)

--- a/src/ybox/run/destroy.py
+++ b/src/ybox/run/destroy.py
@@ -34,27 +34,26 @@ def main_argv(argv: list[str]) -> None:
     docker_cmd = env.docker_cmd
     container_name = args.container_name
 
-    check_ybox_exists(docker_cmd, container_name, exit_on_error=True)
-    print_color(f"Stopping ybox container '{container_name}'", fg=fgcolor.cyan)
+    if check_ybox_exists(docker_cmd, container_name):
+        print_color(f"Stopping ybox container '{container_name}'", fg=fgcolor.cyan)
     # check if there is a systemd service for the container
     ybox_svc_prefix = ybox_systemd_service_prefix(container_name)
     ybox_svc = f"{ybox_svc_prefix}.service"
     systemctl = check_systemd_service_present(ybox_svc)
 
     # continue even if this fails since the container may already be in stopped state
+    if not systemctl or args.force:
+        run_command([docker_cmd, "container", "stop", container_name],
+                    exit_on_error=False, error_msg=f"stopping '{container_name}'")
+        print_warn(f"Removing ybox container '{container_name}'")
+        rm_args = [docker_cmd, "container", "rm"]
+        if args.force:
+            rm_args.append("--force")
+        rm_args.append(container_name)
+        run_command(rm_args, exit_on_error=not args.force, error_msg=f"removing '{container_name}'")
     if systemctl:
         run_command([systemctl, "--user", "stop", ybox_svc],
                     exit_on_error=False, error_msg=f"stopping '{container_name}'")
-    else:
-        run_command([docker_cmd, "container", "stop", container_name],
-                    exit_on_error=False, error_msg=f"stopping '{container_name}'")
-
-    print_warn(f"Removing ybox container '{container_name}'")
-    rm_args = [docker_cmd, "container", "rm"]
-    if args.force:
-        rm_args.append("--force")
-    rm_args.append(container_name)
-    run_command(rm_args, error_msg=f"removing '{container_name}'")
 
     # remove shared TMPDIR if present
     tmpdir = f"/var/tmp/ybox.{container_name}"

--- a/src/ybox/run/destroy.py
+++ b/src/ybox/run/destroy.py
@@ -9,9 +9,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-from ybox.cmd import check_ybox_exists, parser_version_check, run_command
-from ybox.config import Consts
+from ybox.cmd import (check_ybox_exists, delete_container_directory,
+                      parser_version_check, run_command)
+from ybox.config import Consts, StaticConfiguration
 from ybox.env import Environ
+from ybox.pkg.inst import get_parsed_box_conf
 from ybox.print import (fgcolor, print_color, print_error, print_notice,
                         print_warn)
 from ybox.state import YboxStateManagement
@@ -43,15 +45,14 @@ def main_argv(argv: list[str]) -> None:
     systemctl = check_systemd_service_present(ybox_svc)
 
     # continue even if this fails since the container may already be in stopped state
-    if not systemctl or args.force:
-        run_command([docker_cmd, "container", "stop", container_name],
-                    exit_on_error=False, error_msg=f"stopping '{container_name}'")
-        print_warn(f"Removing ybox container '{container_name}'")
-        rm_args = [docker_cmd, "container", "rm"]
-        if args.force:
-            rm_args.append("--force")
-        rm_args.append(container_name)
-        run_command(rm_args, exit_on_error=not args.force, error_msg=f"removing '{container_name}'")
+    run_command([docker_cmd, "container", "stop", container_name],
+                exit_on_error=False, error_msg=f"stopping '{container_name}'")
+    print_warn(f"Removing ybox container '{container_name}'")
+    rm_args = [docker_cmd, "container", "rm"]
+    if args.force:
+        rm_args.append("--force")
+    rm_args.append(container_name)
+    run_command(rm_args, exit_on_error=not args.force, error_msg=f"removing '{container_name}'")
     if systemctl:
         run_command([systemctl, "--user", "stop", ybox_svc],
                     exit_on_error=False, error_msg=f"stopping '{container_name}'")
@@ -62,16 +63,16 @@ def main_argv(argv: list[str]) -> None:
         shutil.rmtree(tmpdir)
 
     # remove systemd service file and reload daemon
+    systemd_dir = env.systemd_user_conf_dir()
     if systemctl:
         print_color(f"Removing systemd service '{ybox_svc}' and reloading daemon", fg=fgcolor.cyan)
         run_command([systemctl, "--user", "disable", ybox_svc], exit_on_error=False)
-        systemd_dir = env.systemd_user_conf_dir()
         Path(systemd_dir, ybox_svc).unlink(missing_ok=True)
-        env_file = f".{ybox_svc_prefix}.env"
-        Path(env.config_dir, env_file).unlink(missing_ok=True)
-        # also try to delete the .env file from the old location
-        Path(systemd_dir, env_file).unlink(missing_ok=True)
         run_command([systemctl, "--user", "daemon-reload"], exit_on_error=False)
+    # remove the .env file
+    Path(env.config_dir, f"{container_name}.env").unlink(missing_ok=True)
+    # also try to delete the .env file from the old location
+    Path(systemd_dir, f".{ybox_svc_prefix}.env").unlink(missing_ok=True)
 
     # check and remove any dangling container references in state database
     valid_containers = set(get_all_containers(docker_cmd))
@@ -80,9 +81,37 @@ def main_argv(argv: list[str]) -> None:
     print_warn(f"Clearing ybox state for '{container_name}'")
     with YboxStateManagement(env) as state:
         state.begin_transaction()
-        if not state.unregister_container(container_name):
+        if (runtime_conf := state.get_container_configuration(container_name)) is None:
             print_error(f"No entry found for '{container_name}' in the state database")
             sys.exit(1)
+        conf = StaticConfiguration(env, runtime_conf.distribution, container_name)
+        print_notice("Removing container configuration files and scripts")
+        shutil.rmtree(conf.configs_dir, ignore_errors=True)
+        shutil.rmtree(conf.scripts_dir, ignore_errors=True)
+        Path(conf.status_file).unlink(missing_ok=True)
+        if not runtime_conf.shared_root:
+            # remove non-shared root directory
+            unshared_root = conf.unshared_root()
+            if os.path.isdir(unshared_root):
+                print_notice(f"Removing unshared root directory {unshared_root}")
+                delete_container_directory(unshared_root, env)
+            # remove the container specific image
+            container_image = conf.box_image(False)
+            print_notice(f"Removing unshared container image {container_image}")
+            run_command([docker_cmd, "image", "rm", container_image], exit_on_error=False,
+                        error_msg="removing unshared container image")
+        # delete all container related files if required
+        if args.delete_files:
+            box_conf = get_parsed_box_conf(runtime_conf.ini_config)
+            assert box_conf is not None
+            home_dir = box_conf["base"]["home"]
+            if os.path.isdir(home_dir):
+                print_notice(f"Removing home directory {home_dir}")
+                delete_container_directory(home_dir, env)
+            container_dir = f"{env.data_dir}/{container_name}"
+            print_notice(f"Removing container directory {container_dir}")
+            delete_container_directory(container_dir, env)
+        state.unregister_container(container_name)
         remove_orphans_from_db(valid_containers, state)
 
 
@@ -96,6 +125,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Stop and remove an active ybox container")
     parser.add_argument("-f", "--force", action="store_true",
                         help="force destroy the container using SIGKILL if required")
+    parser.add_argument("-D", "--delete-files", action="store_true",
+                        help="remove all files of the container including the home directory")
     parser.add_argument("container_name", type=str, help="name of the active ybox")
     parser_version_check(parser, argv)
     return parser.parse_args(argv)

--- a/src/ybox/run/destroy.py
+++ b/src/ybox/run/destroy.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 from ybox.cmd import check_ybox_exists, parser_version_check, run_command
 from ybox.config import Consts
@@ -65,14 +66,11 @@ def main_argv(argv: list[str]) -> None:
         print_color(f"Removing systemd service '{ybox_svc}' and reloading daemon", fg=fgcolor.cyan)
         run_command([systemctl, "--user", "disable", ybox_svc], exit_on_error=False)
         systemd_dir = env.systemd_user_conf_dir()
-        try:
-            os.unlink(f"{systemd_dir}/{ybox_svc}")
-        except OSError:
-            pass
-        try:
-            os.unlink(f"{systemd_dir}/.{ybox_svc_prefix}.env")
-        except OSError:
-            pass
+        Path(systemd_dir, ybox_svc).unlink(missing_ok=True)
+        env_file = f".{ybox_svc_prefix}.env"
+        Path(env.config_dir, env_file).unlink(missing_ok=True)
+        # also try to delete the .env file from the old location
+        Path(systemd_dir, env_file).unlink(missing_ok=True)
         run_command([systemctl, "--user", "daemon-reload"], exit_on_error=False)
 
     # check and remove any dangling container references in state database

--- a/src/ybox/util.py
+++ b/src/ybox/util.py
@@ -19,7 +19,7 @@ from tabulate import tabulate
 
 from ybox import __version__ as product_version
 
-from .cmd import build_shell_command, get_ybox_state
+from .cmd import build_shell_command, check_active_ybox
 from .config import Consts, StaticConfiguration
 from .env import Environ, PathName
 from .print import fgcolor as fg
@@ -220,7 +220,8 @@ def get_ybox_version(conf: StaticConfiguration) -> str:
     return ""
 
 
-def wait_for_ybox_container(docker_cmd: str, conf: StaticConfiguration, timeout: int) -> None:
+def wait_for_ybox_container(docker_cmd: str, conf: StaticConfiguration, timeout: int,
+                            for_stop: bool = False) -> None:
     """
     Wait for container created with `create.start_container` to finish all its initialization.
     This depends on the specific entrypoint script used by `create.start_container` to write
@@ -230,6 +231,7 @@ def wait_for_ybox_container(docker_cmd: str, conf: StaticConfiguration, timeout:
     :param docker_cmd: the podman/docker executable to use
     :param conf: the :class:`StaticConfiguration` for the container
     :param timeout: seconds to wait for container to start before exiting with failure code 1
+    :param for_stop: if True then wait for container to completely stop before returning
     """
     sys.stdout.flush()
     box_name = conf.box_name
@@ -254,23 +256,22 @@ def wait_for_ybox_container(docker_cmd: str, conf: StaticConfiguration, timeout:
         for _ in range(timeout):
             # check the container status first which may be running or stopping
             # in which case sleep and retry (if stopped, then read_lines should succeed)
-            if get_ybox_state(docker_cmd, box_name, expected_states=("running", "stopping")):
-                if read_lines():
+            if check_active_ybox(docker_cmd, box_name):
+                if read_lines() and not for_stop:
                     return
+            elif for_stop:
+                return
             else:
                 time.sleep(1)  # wait for sometime for file write to become visible
                 if read_lines():
                     return
-                print_error("FAILED waiting for container to be ready (last status: "
-                            f"{status_line}).\nCheck 'ybox-logs {box_name}' for more details.")
-                sys.exit(1)
+                break
             # using simple poll per second rather than inotify or similar because the
             # initialization can take a good amount of time and second granularity is enough
             time.sleep(1)
-    # reading did not end after timeout
-    print_error(f"TIMED OUT waiting for ready container after {timeout}secs (last status: "
-                f"{status_line}).\nCheck 'ybox-logs -f {box_name}' for more details.")
-    sys.exit(1)
+        print_error(f"FAILED waiting for container to be ready with timeout={timeout}secs "
+                    f"(last status: {status_line}).\nCheck 'ybox-logs {box_name}' for details.")
+        sys.exit(1)
 
 
 def truncate_file(file: str) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -99,7 +99,7 @@ def test_consts():
                         "entrypoint-common.sh", "entrypoint-root.sh", "entrypoint-user.sh",
                         "prime-run", "run-in-dir", "run-user-bash-cmd")
     assert Consts.resource_scripts() == expected_scripts
-    assert Consts.shared_root_mount_dir() == "/ybox-root"
+    assert Consts.root_mount_dir() == "/ybox-root"
     assert Consts.status_target_file() == "/usr/local/ybox-status"
     assert Consts.entrypoint_init_done_file() == "ybox-init.done"
     assert Consts.container_desktop_dirs() == ("/usr/share/applications",)


### PR DESCRIPTION
The current way the container service works is by stopping and starting the container to utilize its previous state. However, this is not the recommended way to use containers and causing multiple problems in the restart due to even small changes in the system environment. One needs to frequently fully recreate the containers using `ybox-destroy+create` due to this issue, hence the relevant state of the container should be saved and a fresh run be done on a restart.

This is fairly straightforward for the case of `shared_root` where all the relevant directories are already persisted in the host which is why `ybox-destroy+create` also works fine with that setup. However, for the non-shared root case a fresh run will lose the changes in the container, so that should also be modified to use persistent directories in the host (or separate docker volume, though that will also need copying from container of /usr,/var etc so better to use existing `shared_root` mechanism).

This changeset has the following major changes:

- use `podman/docker run` to start the ybox container for all cases
  * updated the service template for this with `CONTAINER_RUN_ARGS` environment variable in the env file that has all the arguments required for the podman/docker run execution
  * skip some env arguments to the run execution like `REQUIRED_PKGS` which are for installing packages only in the initial create and can be quite large, so also reduces the size of `CONTAINER_RUN_ARGS` substantially
  * `ybox-control stop` now also has a `--rm` argument to also remove the container which is now used by the service stop
- use host mounted directories for /usr,/var,... for the non-shared root case too
  * a similar sequence as used for `shared_root` of running a temporary "copy container" is now used for the non-shared root case too; the destination directory is deliberately fixed and not configurable to simplify things a bit
  * renamed `shared_root_dirs` property in distro.ini to `mount_root_dirs` to reflect the fact that it is not specific to the `shared_root` case
  * delete the non-shared root directory on `ybox-destroy` using `podman unshare`; also added removing of the `configs` and `ybox-scripts` directories and optionally also the home and entire container directory with the `-D`/`--delete-files` option to `ybox-destroy`

Few other changes:
- fixed locale-gen for Arch/CachyOS where locale-gen exit value may still be 0 in case a successful one was generated (e.g. en_US may have succeeded by en_IN may have failed), so always reinstall glibc to get all the locales
- removed some non-required packages (like `bat`) in distro.ini of distros